### PR TITLE
add full spec, modify the input format

### DIFF
--- a/src/helm/benchmark/presentation/run_specs_decodingtrust.conf
+++ b/src/helm/benchmark/presentation/run_specs_decodingtrust.conf
@@ -79,6 +79,24 @@ entries: [
   {description: "decodingtrust_adv_demonstration:perspective=counterfactual,data=irregular_form,demo_name=demo+cf,description=irregular_form,model=text", priority=1}
   {description: "decodingtrust_adv_demonstration:perspective=counterfactual,data=main_verb,demo_name=demo+cf,description=main_verb,model=text", priority=1}
   {description: "decodingtrust_adv_demonstration:perspective=counterfactual,data=syntactic_category,demo_name=demo+cf,description=syntactic_category,model=text", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=counterfactual,data=snli_premise,demo_name=demo,description=nli3", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=counterfactual,data=snli_hypothesis,demo_name=demo,description=nli3", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=counterfactual,data=snli_premise,demo_name=cf,description=nli3", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=counterfactual,data=snli_hypothesis,demo_name=cf,description=nli3", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=counterfactual,data=snli_premise,demo_name=zero,description=nli3", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=counterfactual,data=snli_hypothesis,demo_name=zero,description=nli3", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=counterfactual,data=control_raising,demo_name=demo,description=control_raising", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=counterfactual,data=irregular_form,demo_name=demo,description=irregular_form", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=counterfactual,data=main_verb,demo_name=demo,description=main_verb", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=counterfactual,data=syntactic_category,demo_name=demo,description=syntactic_category", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=counterfactual,data=control_raising,demo_name=cf,description=control_raising", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=counterfactual,data=irregular_form,demo_name=cf,description=irregular_form", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=counterfactual,data=main_verb,demo_name=cf,description=main_verb", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=counterfactual,data=syntactic_category,demo_name=cf,description=syntactic_category", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=counterfactual,data=control_raising,demo_name=zero,description=control_raising", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=counterfactual,data=irregular_form,demo_name=zero,description=irregular_form", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=counterfactual,data=main_verb,demo_name=zero,description=main_verb", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=counterfactual,data=syntactic_category,demo_name=zero,description=syntactic_category", priority=1}
   # for spurious
   {description: "decodingtrust_adv_demonstration:perspective=spurious,data=PP,demo_name=entail-bias,description=nli2,model=text", priority=1}
   {description: "decodingtrust_adv_demonstration:perspective=spurious,data=adverb,demo_name=entail-bias,description=nli2,model=text", priority=1}
@@ -92,6 +110,12 @@ entries: [
   {description: "decodingtrust_adv_demonstration:perspective=spurious,data=l_relative_clause,demo_name=non-entail-bias,description=nli2,model=text", priority=1}
   {description: "decodingtrust_adv_demonstration:perspective=spurious,data=passive,demo_name=non-entail-bias,description=nli2,model=text", priority=1}
   {description: "decodingtrust_adv_demonstration:perspective=spurious,data=s_relative_clause,demo_name=non-entail-bias,description=nli2,model=text", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=spurious,data=PP,demo_name=zero,description=nli2", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=spurious,data=adverb,demo_name=zero,description=nli2", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=spurious,data=embedded_under_verb,demo_name=zero,description=nli2", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=spurious,data=l_relative_clause,demo_name=zero,description=nli2", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=spurious,data=passive,demo_name=zero,description=nli2", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=spurious,data=s_relative_clause,demo_name=zero,description=nli2", priority=1}
   # for backdoor
   {description: "decodingtrust_adv_demonstration:perspective=backdoor,data=sst-2,demo_name=setup1_badword,description=sa,model=text", priority=1}
   {description: "decodingtrust_adv_demonstration:perspective=backdoor,data=sst-2,demo_name=setup2_badword,description=sa,model=text", priority=1}
@@ -105,6 +129,15 @@ entries: [
   {description: "decodingtrust_adv_demonstration:perspective=backdoor,data=sst-2,demo_name=setup1_stylebkd,description=sa,model=text", priority=1}
   {description: "decodingtrust_adv_demonstration:perspective=backdoor,data=sst-2,demo_name=setup2_stylebkd,description=sa,model=text", priority=1}
   {description: "decodingtrust_adv_demonstration:perspective=backdoor,data=sst-2,demo_name=setup3_stylebkd,description=sa,model=text", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=backdoor,data=sst-2,demo_name=setup2_cf_first,description=sa", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=backdoor,data=sst-2,demo_name=setup3_cf_first,description=sa", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=backdoor,data=sst-2,demo_name=setup2_cf_middle,description=sa", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=backdoor,data=sst-2,demo_name=setup3_cf_middle,description=sa", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=backdoor,data=sst-2,demo_name=setup2_cf_end,description=sa", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=backdoor,data=sst-2,demo_name=setup3_cf_end,description=sa", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=backdoor,data=sst-2,demo_name=setup2_badword_0,description=sa", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=backdoor,data=sst-2,demo_name=setup2_badword_1,description=sa", priority=1}
+  {description: "decodingtrust_adv_demonstration:perspective=backdoor,data=sst-2,demo_name=setup1_badword,description=badword", priority=1}
 
 
   ### Privacy ###

--- a/src/helm/benchmark/scenarios/decodingtrust_adv_demonstration_scenario.py
+++ b/src/helm/benchmark/scenarios/decodingtrust_adv_demonstration_scenario.py
@@ -114,8 +114,8 @@ class DecodingTrustAdvDemoScenario(Scenario):
 
             cur = self.description + "\n"
             for e in examples:
-                cur += f"Input: {rtrip(e[0])}\nAnswer: {e[1]}\n\n\n"
-            cur += f"Input: {rtrip(x)}\nAnswer: "
+                cur += f"{rtrip(e[0])}\nAnswer: {e[1]}\n\n\n"
+            cur += f"{rtrip(x)}\nAnswer: "
             return cur
 
         for x in dataset:


### PR DESCRIPTION
Note: I check the implementation of in-context learning adapter. It is not suitable for my case as one aspect (counterfactual) requires different demonstration examples for different test inputs. So no change is applied for that part.